### PR TITLE
Add "type" key to package.json in order to support loading as ES6 mod…

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "Rob Resendez (resendez.java@gmail.com)",
   "main": "index.js",
   "module": "index.js",
+  "type": "module",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
…ules with node "experimental-modules".

As per [package.json "type" field](https://nodejs.org/api/esm.html#esm_code_package_json_code_code_type_code_field) enable support for Node.js native `import` statement.